### PR TITLE
🎨[Design] 홈,로그인,회원가입,디테일 페이지 중앙 정렬

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,24 @@
+import { ThemeProvider } from 'styled-components'
 import router from '../routes'
+import useThemeStore from './store/useThemeStore'
 import GlobalStyle from './style/GlobalStyle'
 import { RouterProvider } from 'react-router-dom'
 
 function App() {
+  const { darkMode } = useThemeStore()
+
+  const theme = {
+    bgColor: darkMode ? '#1E1E1E' : '#FFFFFF',
+    color: darkMode ? '#FFFFFF' : '#1E1E1E',
+    borderColor: darkMode ? '#ffffff' : '##C6C6C6'
+  }
+
   return (
     <>
-      <GlobalStyle />
-      <RouterProvider router={router} />
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <RouterProvider router={router} />
+      </ThemeProvider>
     </>
   )
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -23,9 +23,14 @@ function Button({
 export default Button
 
 const BtnButton = styled.button<ButtonProps>`
-  width: 310px;
+  width: 100%;
+  max-width: 310px;
   height: 48px;
   margin-bottom: 20px;
   background-color: ${props => props.$bgcolor};
   color: ${props => props.color};
+  border: 0.5px solid black;
+  border-radius: 5px;
+  font-family: 'GmarketSans';
+  font-size: 16px;
 `

--- a/src/components/CheckAccount.tsx
+++ b/src/components/CheckAccount.tsx
@@ -24,7 +24,8 @@ const CheckAccountButton = styled.button`
   gap: 5px;
   justify-content: center;
   align-items: center;
-  width: 260px;
+  width: 100%;
+  max-width: 300px;
   padding-left: 10px;
   margin: auto;
   margin-top: 40px;
@@ -32,6 +33,8 @@ const CheckAccountButton = styled.button`
   border: 1px solid #bcbcbc;
   border-radius: 5px;
   color: #bcbcbc;
+  font-family: 'GmarketSans';
+  font-size: 16px;
 `
 
 const TextSpan = styled.span`

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,13 @@
+import useThemeStore from '@/store/useThemeStore'
+
+function DarkModeToggle() {
+  const { darkMode, toggleDarkMode } = useThemeStore()
+
+  return (
+    <button onClick={toggleDarkMode}>
+      {darkMode ? 'Light Mode' : 'Dark Mode'}
+    </button>
+  )
+}
+
+export default DarkModeToggle

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 
 interface InputProps {
@@ -24,7 +23,8 @@ function Input({ type, placeholder, maxlength, id }: InputProps) {
 export default Input
 
 const StyledInput = styled.input`
-  width: 260px;
+  width: 100%;
+  max-width: 300px;
   height: 32px;
   border: 1px solid #bcbcbc;
   border-radius: 5px;
@@ -33,5 +33,6 @@ const StyledInput = styled.input`
 
   &::placeholder {
     color: #bcbcbc;
+    font-family: 'GmarketSans';
   }
 `

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 
 function Logo() {
@@ -8,7 +7,8 @@ function Logo() {
 export default Logo
 
 const LogoDiv = styled.div`
-  width: 310px;
+  width: 100%;
+  max-width: 310px;
   height: 80px;
   border: 1px solid black;
   border-radius: 5px;

--- a/src/layout/Fake.tsx
+++ b/src/layout/Fake.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+
+function Fake() {
+  return <FakeDiv></FakeDiv>
+}
+
+export default Fake
+
+const FakeDiv = styled.div`
+  height: 100px;
+`

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { faAngleLeft } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import DarkModeToggle from '@/components/DarkModeToggle'
 
 function Header() {
   return (
@@ -8,6 +9,7 @@ function Header() {
       <ArrowDiv>
         <FontAwesomeIcon icon={faAngleLeft} />
       </ArrowDiv>
+      <DarkModeToggle />
     </HeaderDiv>
   )
 }

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -4,18 +4,26 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 function Header() {
   return (
-    <ArrowDiv>
-      <FontAwesomeIcon icon={faAngleLeft} />
-    </ArrowDiv>
+    <HeaderDiv>
+      <ArrowDiv>
+        <FontAwesomeIcon icon={faAngleLeft} />
+      </ArrowDiv>
+    </HeaderDiv>
   )
 }
 
 export default Header
 
+const HeaderDiv = styled.div`
+  width: 100%;
+  max-width: 370px;
+`
+
 const ArrowDiv = styled.div`
-  width: 100vw;
+  width: 100%;
   display: flex;
   justify-content: start;
+  align-items: center;
+  padding: 10px;
   border-bottom: 2px solid black;
-  padding-bottom: 10px;
 `

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,7 +1,6 @@
 import DetailReview from '@/components/DetailReview'
 import { faStar, faStarHalfStroke } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React from 'react'
 import styled from 'styled-components'
 
 function Detail() {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -29,8 +29,9 @@ const SrOnlyH1 = styled.h1`
 `
 
 const HomeDivWrapper = styled.div`
-  width: 390px;
-  margin: auto;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
 `
 
 const ButtonDivWrapper = styled.div`

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -37,6 +37,7 @@ export default Login
 
 const LogoWrapper = styled.div`
   margin-bottom: -40px;
+  width: 100%;
 `
 
 const LoginFormWrapper = styled(FormWrapper)`
@@ -47,6 +48,7 @@ const LoginFormWrapper = styled(FormWrapper)`
 `
 
 const InputWrapper = styled.div`
+  width: 100%;
   position: relative;
   padding: 10px 0;
   display: flex;
@@ -56,8 +58,8 @@ const InputWrapper = styled.div`
 
 const EyeDiv = styled.div`
   position: absolute;
-  right: 60px;
-  top: 60px;
+  right: 0px;
+  top: 65px;
   width: 30px;
   height: 30px;
 `

--- a/src/pages/RootLayout.tsx
+++ b/src/pages/RootLayout.tsx
@@ -1,7 +1,8 @@
 import Nav from '@/layout/Nav'
 import Header from '@/layout/Header'
 import { Outlet } from 'react-router-dom'
-import { createGlobalStyle } from 'styled-components'
+import styled, { createGlobalStyle } from 'styled-components'
+import Fake from '@/layout/Fake'
 
 const GlobalStyle = createGlobalStyle`
   body, #root {
@@ -14,11 +15,20 @@ export default function RootLayout() {
   return (
     <>
       <GlobalStyle />
-      <main>
+      <MainWrapper>
         <Header />
         <Outlet />
+        <Fake />
         <Nav />
-      </main>
+      </MainWrapper>
     </>
   )
 }
+
+const MainWrapper = styled.main`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`

--- a/src/pages/RootLayout.tsx
+++ b/src/pages/RootLayout.tsx
@@ -4,17 +4,17 @@ import { Outlet } from 'react-router-dom'
 import styled, { createGlobalStyle } from 'styled-components'
 import Fake from '@/layout/Fake'
 
-const GlobalStyle = createGlobalStyle`
-  body, #root {
-    margin: 0;
-    padding: 0;
-  }
-`
+// const GlobalStyle = createGlobalStyle`
+//   body, #root {
+//     margin: 0;
+//     padding: 0;
+//   }
+// `
 
 export default function RootLayout() {
   return (
     <>
-      <GlobalStyle />
+      {/* <GlobalStyle /> */}
       <MainWrapper>
         <Header />
         <Outlet />

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -46,8 +46,7 @@ function SignUp() {
 export default SignUp
 
 export const SignUpWrapperDiv = styled.div`
-  width: 390px;
-  margin: auto;
+  width: 90%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -64,6 +63,7 @@ export const SrOnlyH2 = styled.h2`
   border: 0;
 `
 export const FormWrapper = styled.form`
+  width: 90%;
   padding: 30px 0 20px 0;
   border-top: 1px solid #bcbcbc;
   border-bottom: 1px solid #bcbcbc;
@@ -73,14 +73,15 @@ export const FormWrapper = styled.form`
 `
 
 const AgreeDiv = styled.div`
+  width: 100%;
+  max-width: 300px;
   display: flex;
   gap: 10px;
   justify-content: start;
   align-items: center;
-  width: 260px;
-  padding-left: 10px;
-  margin: auto;
   margin-bottom: 10px;
+  padding-right: 10px;
+  color: #777777;
 `
 
 const AllAgreeDiv = styled(AgreeDiv)`

--- a/src/store/useThemeStore.ts
+++ b/src/store/useThemeStore.ts
@@ -6,8 +6,14 @@ interface themeStore {
 }
 
 const useThemeStore = create<themeStore>(set => ({
-  darkMode: false,
-  toggleDarkMode: () => set(state => ({ darkMode: !state.darkMode }))
+  darkMode: localStorage.getItem('darkMode') === 'true',
+  toggleDarkMode: () => {
+    set(state => {
+      const newDarkMode = !state.darkMode
+      localStorage.setItem('darkMode', newDarkMode.toString())
+      return { darkMode: newDarkMode }
+    })
+  }
 }))
 
 export default useThemeStore

--- a/src/store/useThemeStore.ts
+++ b/src/store/useThemeStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+interface themeStore {
+  darkMode: boolean
+  toggleDarkMode: () => void
+}
+
+const useThemeStore = create<themeStore>(set => ({
+  darkMode: false,
+  toggleDarkMode: () => set(state => ({ darkMode: !state.darkMode }))
+}))
+
+export default useThemeStore

--- a/src/style/GlobalStyle.ts
+++ b/src/style/GlobalStyle.ts
@@ -9,6 +9,9 @@ body, #root {
     padding: 0;
     margin-left : auto;
     margin-right: auto;
+  background: ${({ theme }) => theme.bgColor};
+  color: ${({ theme }) => theme.color};
+  border-color: ${({ theme }) => theme.borderColor};
   }
 `
 

--- a/src/style/GlobalStyle.ts
+++ b/src/style/GlobalStyle.ts
@@ -13,6 +13,9 @@ body, #root {
   color: ${({ theme }) => theme.color};
   border-color: ${({ theme }) => theme.borderColor};
   }
+  button {
+  cursor: pointer;
+    }
 `
 
 export default GlobalStyle

--- a/src/style/GlobalStyle.ts
+++ b/src/style/GlobalStyle.ts
@@ -7,7 +7,6 @@ body, #root {
     color: #303032;
     margin: 0;
     padding: 0;
-    width: 390px;
     margin-left : auto;
     margin-right: auto;
   }


### PR DESCRIPTION
## 🚀 변경 사항

**설명:**
- 홈,로그인,회원가입,디테일 페이지 중앙 정렬되도록 했습니다.
**관련 이슈:**
이 PR과 관련된 이슈가 있다면 여기에 링크를 추가해주세요.

**테스트:**
이 변경을 어떻게 테스트했는지 설명해주세요.

**스크린샷 (선택 사항):**
<img width="494" alt="스크린샷 2023-12-07 오후 4 15 01" src="https://github.com/bomlang/FESP01-BABA/assets/130597261/49fe8cb1-cd51-476f-a0b2-9de9fe72a49a">

---

**체크리스트:**

- [x] 코드는 문제없이 빌드 및 실행됩니다.
- [x] 코드 스타일은 프로젝트 규칙을 따릅니다.
- [x] 새로운 기능은 테스트되었고, 기존 기능에 영향을 미치지 않습니다.
- [ ] 관련사항을 이슈템플릿에 추가하였습니다.

---

**도움이 필요한 부분 (선택 사항):**
비밀번호 보이게 하는 눈알 이미지를 반응형에 따라 적절하게  위치하도록 해야합니다.

**리뷰 포인트 (선택 사항):**
리뷰어들이 특히 주목해야 할 부분이 있다면 여기에 명시해주세요.
