### PR TITLE
프로필 페이지 레이아웃 수정 및 스와이퍼 추가

### DIFF
--- a/src/components/FeedComponent.tsx
+++ b/src/components/FeedComponent.tsx
@@ -70,8 +70,6 @@ function FeedComponent({ reviews }: { reviews: ReviewData[] }) {
           throw new Error('Failed to fetch review data')
         }
 
-        console.log(reviewData)
-
         // 데이터의 날짜를 최신 순서부터 오래된 순서로 나열합니다.
         const sortedReviewData = sortReviewDataByDate(reviewData)
         // updateReviewData(sortedReviewData);
@@ -201,7 +199,6 @@ function FeedComponent({ reviews }: { reviews: ReviewData[] }) {
 
     setIsLiked(prevState => !prevState)
   }
-  console.log(reviews)
 
   return (
     <FeedSection>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -16,18 +16,21 @@ import { faPenToSquare, faStar } from '@fortawesome/free-solid-svg-icons'
 import { faHeart } from '@fortawesome/free-solid-svg-icons'
 import userInfoInLs from '@/utils/userInfoInLs'
 import { getMyLikes } from '@/api/getLikesData'
-// import useThemeStore from '@/store/useThemeStore'
+import useThemeStore from '@/store/useThemeStore'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import 'swiper/css'
+import { Pagination } from 'swiper/modules'
 
 interface PostProps {
   key: number
 }
 
-// interface BorderProps {
-//   $darkMode: boolean
-// }
+interface DarkModeProps {
+  $darkMode: boolean
+}
 
 function MyPage() {
-  // const { $darkMode } = useThemeStore()
+  const { $darkMode } = useThemeStore()
   const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const [userId, setUserId] = useState<string | null>(null)
@@ -159,7 +162,7 @@ function MyPage() {
 
           return lengthComparison
         })
-        .slice(0, 4)
+        .slice(0, 10)
 
       setPopularReviews(sortedPopularReviews)
     }
@@ -258,15 +261,29 @@ function MyPage() {
           </ProfileInfo>
         </ProfileContain>
 
-        <Container>
-          {popularReviews && popularReviews.length > 0
-            ? popularReviews.map(popular => (
-                <FavRing review={popular} key={popular.id} />
-              ))
-            : null}
-        </Container>
+        {popularReviews && popularReviews.length > 0 ? (
+          <Swiper
+            className="mySwiper"
+            slidesPerView={4}
+            breakpoints={{
+              700: {
+                slidesPerView: 6
+              }
+            }}
+            loop={true}
+            modules={[Pagination]}
+          >
+            <Container>
+              {popularReviews.map(popular => (
+                <SwiperSlide key={popular.id}>
+                  <FavRing review={popular} />
+                </SwiperSlide>
+              ))}
+            </Container>
+          </Swiper>
+        ) : null}
 
-        <MarginContainer>
+        <MarginContainer $darkMode={$darkMode}>
           <Wrapper onClick={handleShowReviews}>
             <StyledP>게시물</StyledP>
             <span>{reviews?.length}</span>
@@ -429,6 +446,7 @@ const ProfileBtn = styled.button`
   border: none;
   margin-top: 15px; /* Add some spacing */
   cursor: pointer;
+  color: #303032;
 
   &:hover {
     background-color: #0282d1;
@@ -442,12 +460,13 @@ const Container = styled.div`
   margin: 0 auto;
 `
 
-const MarginContainer = styled.div`
+const MarginContainer = styled.div<DarkModeProps>`
   display: flex;
   width: 100%;
   gap: 15px;
   margin: 15px 0;
   border: 1px solid black;
+  border-color: ${({ $darkMode }) => ($darkMode ? '#FFFFFF' : '#303032')};
   justify-content: space-between;
 
   @media (max-width: 700px) {

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -504,10 +504,13 @@ const PostsContain = styled.section`
   flex-wrap: wrap;
   gap: 1px;
   width: 100%;
+  justify-content: start;
 `
 
 const Post = styled.div<PostProps>`
-  width: 129px;
+  width: calc(
+    25% - 1px
+  ); /* 4개의 아이템이 한 줄에 나타날 수 있도록 너비를 조절합니다. */
   height: 129px;
   background-color: #0282d1;
   cursor: pointer;
@@ -543,6 +546,12 @@ export const HoverLink = styled(Link)`
   }
 `
 
+const PostImg = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`
+
 export const HoverDiv = styled.div`
   width: 100px;
   position: absolute;
@@ -552,7 +561,6 @@ export const HoverDiv = styled.div`
   text-align: center;
   visibility: hidden;
 `
-
 export const MovieTitleSpan = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
@@ -565,12 +573,6 @@ const RatingSpan = styled.span`
   display: block;
   padding-top: 10px;
   color: #ffc61a;
-`
-
-const PostImg = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
 `
 
 const PictureWrapper = styled.div`

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -29,6 +29,11 @@ interface DarkModeProps {
   $darkMode: boolean
 }
 
+interface WrapperProps {
+  $bgColor: string
+  color: string
+}
+
 function MyPage() {
   const { $darkMode } = useThemeStore()
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -223,6 +228,11 @@ function MyPage() {
     }
   }
 
+  //# 로그아웃
+  const handleLogOut = () => {
+    console.log('로그아웃')
+  }
+
   return (
     <Box>
       <ContentBox>
@@ -255,9 +265,12 @@ function MyPage() {
 
           <ProfileInfo>
             <p>{userEmail}</p>
-            <ProfileBtn onClick={handleDeleteProfileImg}>
-              프로필 편집
-            </ProfileBtn>
+            <ProfileBtnWrapper>
+              <ProfileBtn onClick={handleDeleteProfileImg}>
+                프로필 편집
+              </ProfileBtn>
+              <ProfileBtn onClick={handleLogOut}>로그아웃</ProfileBtn>
+            </ProfileBtnWrapper>
           </ProfileInfo>
         </ProfileContain>
 
@@ -284,12 +297,20 @@ function MyPage() {
         ) : null}
 
         <MarginContainer $darkMode={$darkMode}>
-          <Wrapper onClick={handleShowReviews}>
+          <Wrapper
+            onClick={handleShowReviews}
+            color={isShowReviews ? '#FFFFFF' : ''}
+            $bgColor={isShowReviews ? '#3797EF' : ''}
+          >
             <StyledP>게시물</StyledP>
             <span>{reviews?.length}</span>
           </Wrapper>
 
-          <Wrapper onClick={handleShowLikes}>
+          <Wrapper
+            onClick={handleShowLikes}
+            color={!isShowReviews ? '#FFFFFF' : ''}
+            $bgColor={!isShowReviews ? '#3797EF' : ''}
+          >
             <StyledP>좋아요</StyledP>
             <span>{myLikes?.length}</span>
           </Wrapper>
@@ -432,11 +453,22 @@ const ProfileImage = styled.img`
 
 const ProfileInfo = styled.div`
   margin-top: 15px; /* Add some spacing */
-  text-align: center;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`
+
+const ProfileBtnWrapper = styled.div`
+  width: 80%;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
 `
 
 const ProfileBtn = styled.button`
-  width: 100%;
+  width: 45%;
   height: 40px;
   background-color: #efefef;
   display: flex;
@@ -463,7 +495,6 @@ const Container = styled.div`
 const MarginContainer = styled.div<DarkModeProps>`
   display: flex;
   width: 100%;
-  gap: 15px;
   margin: 15px 0;
   border: 1px solid black;
   border-color: ${({ $darkMode }) => ($darkMode ? '#FFFFFF' : '#303032')};
@@ -475,28 +506,31 @@ const MarginContainer = styled.div<DarkModeProps>`
   }
 `
 
-const Wrapper = styled.button`
+const Wrapper = styled.div<WrapperProps>`
   width: 48%; /* Two columns on larger screens */
   border: none;
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 15px 0;
-  gap: 10px;
   cursor: pointer;
-
-  &:hover {
-    background-color: #0282d1;
-    color: #ffffff;
-  }
+  background-color: ${({ $bgColor }) => $bgColor};
+  color: ${({ color }) => color};
+  flex-grow: 1;
 
   @media (max-width: 700px) {
     width: 100%; /* Full-width on smaller screens */
+  }
+
+  &:hover {
+    background-color: #fffc9f;
+    color: black;
   }
 `
 
 const StyledP = styled.p`
   margin: 0;
+  padding-bottom: 10px;
 `
 
 const PostsContain = styled.section`

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -42,6 +42,7 @@ function MyPage() {
   const [userEmail, setUserEmail] = useState<string | null>(null)
   const [profileImg, setProfileImg] = useState<File | null>(null)
   const [renderProfileImg, setRenderProfileImg] = useState<string | null>(null)
+
   const [reviews, setReviews] = useState<ReviewsProps[] | null>(null)
   const [isShowReviews, setIsShowReviews] = useState<boolean>(true)
   const [popularReviews, setPopularReviews] = useState<ReviewsProps[] | null>(
@@ -247,6 +248,7 @@ function MyPage() {
                 }
                 alt="사용자 이미지"
                 onClick={handleProfileImg}
+                $shouldInvert={!renderProfileImg} // renderProfileImg가 true이면 invert를 적용하지 않음
               />
               <div>
                 <label htmlFor="photo">사진</label>
@@ -444,13 +446,16 @@ const ImageWrapper = styled.div`
   overflow: hidden;
 `
 
-const ProfileImage = styled.img<{ theme: { bgColor: string } }>`
+const ProfileImage = styled.img<{
+  theme: { bgColor: string }
+  $shouldInvert: boolean
+}>`
   width: 100%;
   height: 100%;
   object-fit: cover;
   cursor: pointer;
-  filter: ${props =>
-    props.theme.bgColor === '#1E1E1E' ? 'invert(1)' : 'none'};
+  filter: ${({ theme, $shouldInvert }) =>
+    $shouldInvert && theme.bgColor === '#1E1E1E' ? 'invert(1)' : 'none'};
 `
 
 const ProfileInfo = styled.div`

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import userImage from '@/assets/userIcon.png'
+import UserIcon from '@/assets/icon/User.png'
 import { Link, useNavigate } from 'react-router-dom'
 import { getUserReviews } from '@/api/reviewApi'
 import FavRing from '@/components/mypage/FavRing'
@@ -243,7 +243,7 @@ function MyPage() {
                 src={
                   renderProfileImg
                     ? `https://ufinqahbxsrpjbqmrvti.supabase.co/storage/v1/object/public/userImage/${renderProfileImg}`
-                    : userImage
+                    : UserIcon
                 }
                 alt="사용자 이미지"
                 onClick={handleProfileImg}
@@ -444,11 +444,13 @@ const ImageWrapper = styled.div`
   overflow: hidden;
 `
 
-const ProfileImage = styled.img`
+const ProfileImage = styled.img<{ theme: { bgColor: string } }>`
   width: 100%;
   height: 100%;
   object-fit: cover;
   cursor: pointer;
+  filter: ${props =>
+    props.theme.bgColor === '#1E1E1E' ? 'invert(1)' : 'none'};
 `
 
 const ProfileInfo = styled.div`

--- a/src/pages/Writing.tsx
+++ b/src/pages/Writing.tsx
@@ -111,8 +111,7 @@ function Writing() {
     } catch (error) {
       console.error(error)
     } finally {
-      inputRef.current!.value = ''
-      // 검색 후에는 검색 버튼을 다시 비활성화
+      inputRef.current!.value = '' // 검색 후에는 검색 버튼을 다시 비활성화
     }
   }
 
@@ -120,7 +119,6 @@ function Writing() {
   const handleSelectMovie = (selectedResult: SearchListProps) => {
     setSelectMovie(selectedResult)
     setSearchList([])
-
     setIsSearchBtnDisabled(false)
     setDefaultImg(selectedResult?.poster_path)
     setIsSearched(false) // 영화를 선택하면 검색이 완료된 상태를 false로 설정
@@ -136,10 +134,6 @@ function Writing() {
   }
 
   const handleSelectUserImg = () => {
-    if (!selectMovie) {
-      alert('제목을 먼저 선택해주세요')
-      return
-    }
     setIsSelectImg(false)
   }
 
@@ -278,7 +272,7 @@ function Writing() {
       <FormStyle encType="multipart/form-data">
         <SearchContainerWrapper>
           <FlexContainer>
-            <SearchBarWrapper isSearchBtnDisabled={isSearchBtnDisabled}>
+            <SearchBarWrapper $isSearchBtnDisabled={isSearchBtnDisabled}>
               <SearchBar>
                 <Icon>
                   <FontAwesomeIcon icon={faMagnifyingGlass} />
@@ -294,8 +288,8 @@ function Writing() {
             </SearchBarWrapper>
 
             <ResultWrapper
-              issearched={isSearched}
-              isSearchBtnDisabled={isSearchBtnDisabled}
+              $isSearched={isSearched}
+              $isSearchBtnDisabled={isSearchBtnDisabled}
             >
               <SearchContainer>
                 {searchList.map(result => (
@@ -350,11 +344,11 @@ function Writing() {
                 />
               ) : (
                 <>
-                  {imgSrc && selectMovie ? ( // 사용자가 이미지를 업로드한 경우
+                  {imgSrc ? ( // 사용자가 이미지를 업로드한 경우
                     <MoviePoster
                       src={imgSrc}
                       alt={`${
-                        selectMovie.title || selectMovie.name
+                        selectMovie?.title || selectMovie?.name
                       } 관련 이미지`}
                       onClick={handleDeleteImg}
                     />
@@ -379,43 +373,6 @@ function Writing() {
                 </>
               )}
             </OriginalImage>
-            {/* <OriginalImage>
-              {selectMovie && isSelectImg ? (
-                <MoviePoster
-                  src={`https://image.tmdb.org/t/p/original/${selectMovie.poster_path}`}
-                  alt={`${selectMovie.title || selectMovie.name} 포스터`}
-                />
-              ) : (
-                selectMovie && (
-                  <>
-                    <MoviePoster
-                      src={imgSrc}
-                      alt={`${
-                        selectMovie.title || selectMovie.name
-                      } 관련 이미지`}
-                      onClick={handleDeleteImg}
-                    />
-                  ) : (
-                    // 사용자가 이미지를 업로드하지 않았거나 selectMovie가 없는 경우
-                    <PlzSelectImgDiv>
-                      <FontAwesomeIcon icon={faImage} />
-                    </PlzSelectImgDiv>
-                  )}
-                  {!isSelectImg && (
-                    <div>
-                      <label htmlFor="photo">사진</label>
-                      <input
-                        type="file"
-                        accept=".jpg, .jpeg, .png"
-                        name="photo"
-                        id="photo"
-                        onChange={handleUpload}
-                      />
-                    </div>
-                  )}
-                </>
-              )}
-            </OriginalImage> */}
           </ImageBox>
 
           <Description>
@@ -437,7 +394,7 @@ function Writing() {
                         src={icon}
                         alt={ottIconNames[index]}
                         title={ottIconNames[index]}
-                        isSelected={selectedOtt.includes(ottIconNames[index])}
+                        $isSelected={selectedOtt.includes(ottIconNames[index])}
                         onClick={() => handleCheck(ottIconNames[index])}
                       />
                     </Style>
@@ -531,7 +488,7 @@ const ImageBox = styled.div`
   }
 `
 
-const SearchBarWrapper = styled.div<{ isSearchBtnDisabled: boolean }>`
+const SearchBarWrapper = styled.div<{ $isSearchBtnDisabled: boolean }>`
   display: flex;
   flex: 1;
   align-items: center;
@@ -541,9 +498,9 @@ const SearchBarWrapper = styled.div<{ isSearchBtnDisabled: boolean }>`
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
   border-bottom-left-radius: ${props =>
-    props.isSearchBtnDisabled ? '8px' : 'none'};
+    props.$isSearchBtnDisabled ? '8px' : 'none'};
   border-bottom-right-radius: ${props =>
-    props.isSearchBtnDisabled ? '8px' : 'none'};
+    props.$isSearchBtnDisabled ? '8px' : 'none'};
   background-color: #e8e8e8;
 
   @media (min-width: 701px) {
@@ -589,8 +546,8 @@ const SearchBar = styled.div`
 `
 
 const ResultWrapper = styled.div<{
-  issearched: boolean
-  isSearchBtnDisabled: boolean
+  $isSearched: boolean
+  $isSearchBtnDisabled: boolean
 }>`
   width: 100%;
   position: absolute;
@@ -654,12 +611,12 @@ const Style = styled.div`
   height: 60px;
 `
 
-const OttIcon = styled.img<{ isSelected: boolean }>`
+const OttIcon = styled.img<{ $isSelected: boolean }>`
   width: 100%;
   height: 100%;
   object-fit: cover;
   cursor: pointer;
-  border: ${({ isSelected }) => (isSelected ? '2px solid #3797EF' : 'none')};
+  border: ${({ $isSelected }) => ($isSelected ? '2px solid #3797EF' : 'none')};
 
   &:hover {
     transform: scale(1.1);
@@ -710,9 +667,9 @@ const ImgSelectBtn = styled.button<{ $hasBorder?: boolean; color?: string }>`
     cursor: default;
   }
 
-  &:not(.selected):hover {
+  /* &:not(.selected):hover {
     background-color: #3797ef;
-  }
+  } */
 `
 
 const OriginalImage = styled.div`

--- a/src/pages/Writing.tsx
+++ b/src/pages/Writing.tsx
@@ -667,9 +667,10 @@ const ImgSelectBtn = styled.button<{ $hasBorder?: boolean; color?: string }>`
     cursor: default;
   }
 
-  /* &:not(.selected):hover {
-    background-color: #3797ef;
-  } */
+  &:not(.selected):hover {
+    background-color: #fffc9f;
+    color: black;
+  }
 `
 
 const OriginalImage = styled.div`


### PR DESCRIPTION
## 🚀 변경 사항

**설명:**
- 게시물 렌더링 시 오른쪽 여백 생기는 이슈 해결함
- 기본 프로필 이미지 변경
- 좋아요 많이 받은 글 10개까지 렌더링 되도록 하고 스와이퍼 적용함
- 로그아웃 버튼 생성

**관련 이슈:**
이 PR과 관련된 이슈가 있다면 여기에 링크를 추가해주세요.

**테스트:**
이 변경을 어떻게 테스트했는지 설명해주세요.

**스크린샷 (선택 사항):**
만약 가능하다면 변경사항을 시각적으로 보여줄 수 있는 스
<img width="732" alt="스크린샷 2023-12-24 오후 3 13 49" src="https://github.com/bomlang/FESP01-BABA/assets/130597261/0cb9e12d-38ff-4b98-9ff9-29ceae02649b">
크린샷을 첨부해주세요.

---

**체크리스트:**

- [x] 코드는 문제없이 빌드 및 실행됩니다.
- [x] 코드 스타일은 프로젝트 규칙을 따릅니다.
- [x] 새로운 기능은 테스트되었고, 기존 기능에 영향을 미치지 않습니다.
- [ ] 관련사항을 이슈템플릿에 추가하였습니다.

---

**도움이 필요한 부분 (선택 사항):**
도움이 필요한 부분이나 특별한 고려사항이 있다면 여기에 작성해주세요.

**리뷰 포인트 (선택 사항):**
리뷰어들이 특히 주목해야 할 부분이 있다면 여기에 명시해주세요.
